### PR TITLE
Fit the resume page to a single page

### DIFF
--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -13,7 +13,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   html {
-    font-size: 62.5%;
+    font-size: ${themeGet('baseFontSize', '62.5%')};
   }
 
   body {

--- a/src/content/about.tsx
+++ b/src/content/about.tsx
@@ -53,127 +53,148 @@ export const jobs = [
 
 type Props = {
   personal?: boolean
+  compact?: boolean
 }
 
-export const AboutMe: FC<Props> = ({ personal = true }) => (
-  <>
-    <Heading as='h2' fontFamily='heading' fontSize='8' mb='5'>
-      About Me
-    </Heading>
+// `compact` tightens the fixed 3.2rem line-height used throughout this file.
+// It's the one hand-picked value the printer theme's proportional font/space
+// scaling (see theme.ts) can't reach, since it's a literal CSS value rather
+// than a theme lookup. Only resume.tsx passes compact — the /about page keeps
+// the normal, more relaxed spacing.
+const lineHeightFor = (compact?: boolean) => (compact ? '2.2rem' : '3.2rem')
 
-    <Box color='gray.200'>
-      <Text lineHeight='3.2rem'>
-        Hey there! 👋 I'm Iago — a software engineer from Brazil. I build
-        products end to end: frontend-first, but happy to follow a problem into
-        the backend, the database, or the design file.
-      </Text>
+export const AboutMe: FC<Props> = ({ personal = true, compact = false }) => {
+  const lineHeight = lineHeightFor(compact)
 
-      <Text lineHeight='3.2rem' mt='4'>
-        For about a year and a half I was a Senior Software Engineer at Clerk,
-        working on the B2B side of the authentication platform. I worked across
-        the stack, React and TypeScript in the dashboard and Go on the backend,
-        on organizations, SSO and enterprise connections (SAML and OIDC), SCIM
-        directory sync, and roles & permissions.
-      </Text>
+  return (
+    <>
+      <Heading as='h2' fontFamily='heading' fontSize='8' mb='5'>
+        About Me
+      </Heading>
 
-      <Text lineHeight='3.2rem' mt='4'>
-        Before Clerk I was at Sticker Mule, and spent five years at Codeminer42
-        consulting for teams like GoDaddy, StackCommerce, and Folha de S.Paulo.
-        The way I like to work: ship in small, well-tested increments, sweat the
-        corner cases, and keep software maintainable as it grows.
-      </Text>
-
-      {personal && (
-        <Text lineHeight='3.2rem' mt='4'>
-          I live in Florianópolis with my wife 👩, our crazy dog Helga 🐶, and
-          our daughter Ramona 👶. When I'm not working you'll find me playing
-          with Ramona, sneaking in a video game when she lets me, cooking for
-          the family (Sunday BBQ 🍖 is sacred), or fixing something around the
-          house.
+      <Box color='gray.200'>
+        <Text lineHeight={lineHeight}>
+          Hey there! 👋 I'm Iago — a software engineer from Brazil. I build
+          products end to end: frontend-first, but happy to follow a problem
+          into the backend, the database, or the design file.
         </Text>
-      )}
 
-      {personal && (
-        <Text lineHeight='3.2rem' mt='4'>
-          I'm currently looking for a new role. If you're building something
-          interesting,{' '}
-          <Text
-            as={motion.a}
-            href='mailto:iagodahlemlorensini@gmail.com'
-            whileHover={{ opacity: 0.6 }}
-            fontWeight='600'
-          >
-            say hi
+        <Text lineHeight={lineHeight} mt='4'>
+          For about a year and a half I was a Senior Software Engineer at Clerk,
+          working on the B2B side of the authentication platform. I worked
+          across the stack, React and TypeScript in the dashboard and Go on the
+          backend, on organizations, SSO and enterprise connections (SAML and
+          OIDC), SCIM directory sync, and roles & permissions.
+        </Text>
+
+        <Text lineHeight={lineHeight} mt='4'>
+          Before Clerk I was at Sticker Mule, and spent five years at
+          Codeminer42 consulting for teams like GoDaddy, StackCommerce, and
+          Folha de S.Paulo. The way I like to work: ship in small, well-tested
+          increments, sweat the corner cases, and keep software maintainable as
+          it grows.
+        </Text>
+
+        {personal && (
+          <Text lineHeight={lineHeight} mt='4'>
+            I live in Florianópolis with my wife 👩, our crazy dog Helga 🐶, and
+            our daughter Ramona 👶. When I'm not working you'll find me playing
+            with Ramona, sneaking in a video game when she lets me, cooking for
+            the family (Sunday BBQ 🍖 is sacred), or fixing something around the
+            house.
           </Text>
-          .
-        </Text>
-      )}
-    </Box>
-  </>
-)
+        )}
 
-export const Experience = () => (
-  <>
-    <Heading as='h3' fontFamily='heading' fontSize='7' mt='5'>
-      Experience
-    </Heading>
-
-    <Box mt='4'>
-      {jobs.map((job) => {
-        const startDate = format(job.startDate, 'LLL, yyyy')
-        const endDate = job.endDate
-          ? format(job.endDate, 'LLL, yyyy')
-          : 'Present'
-
-        const durationObj = intervalToDuration({
-          start: job.startDate,
-          end: job.endDate ?? new Date(),
-        })
-
-        const durationFormat =
-          durationObj.years || durationObj.months
-            ? ['years', 'months']
-            : ['days']
-
-        const duration = formatDuration(durationObj, {
-          format: durationFormat,
-        })
-
-        return (
-          <Box
-            key={`${job.jobTitle}-${job.companyName}`}
-            css={css({ ':not(:last-child)': { mb: '4' } })}
-          >
+        {personal && (
+          <Text lineHeight={lineHeight} mt='4'>
+            I'm currently looking for a new role. If you're building something
+            interesting,{' '}
             <Text
               as={motion.a}
-              href={job.companyUrl}
+              href='mailto:iagodahlemlorensini@gmail.com'
               whileHover={{ opacity: 0.6 }}
               fontWeight='600'
-              lineHeight='3.2rem'
             >
-              {job.companyName}
+              say hi
             </Text>
+            .
+          </Text>
+        )}
+      </Box>
+    </>
+  )
+}
 
-            <Text lineHeight='3.2rem'>
-              {job.jobTitle} •{' '}
-              <Text as='span' color='gray.300'>
-                {job.jobType}
+export const Experience: FC<{ compact?: boolean }> = ({ compact = false }) => {
+  const lineHeight = lineHeightFor(compact)
+
+  return (
+    <>
+      <Heading as='h3' fontFamily='heading' fontSize='7' mt='5'>
+        Experience
+      </Heading>
+
+      <Box mt='4'>
+        {jobs.map((job) => {
+          const startDate = format(job.startDate, 'LLL, yyyy')
+          const endDate = job.endDate
+            ? format(job.endDate, 'LLL, yyyy')
+            : 'Present'
+
+          const durationObj = intervalToDuration({
+            start: job.startDate,
+            end: job.endDate ?? new Date(),
+          })
+
+          const durationFormat =
+            durationObj.years || durationObj.months
+              ? ['years', 'months']
+              : ['days']
+
+          const duration = formatDuration(durationObj, {
+            format: durationFormat,
+          })
+
+          return (
+            <Box
+              key={`${job.jobTitle}-${job.companyName}`}
+              css={css({ ':not(:last-child)': { mb: '4' } })}
+            >
+              <Text
+                as={motion.a}
+                href={job.companyUrl}
+                whileHover={{ opacity: 0.6 }}
+                fontWeight='600'
+                lineHeight={lineHeight}
+              >
+                {job.companyName}
               </Text>
-            </Text>
 
-            <Text fontSize='1.4rem' lineHeight='3.2rem' color='gray.300'>
-              {startDate} &#8212; {endDate} • {duration}
-            </Text>
-
-            {job.detail && <Text lineHeight='3.2rem'>{job.detail}</Text>}
-            {job.stack && (
-              <Text fontSize='1.4rem' lineHeight='3.2rem' color='gray.300'>
-                {job.stack}
+              <Text lineHeight={lineHeight}>
+                {job.jobTitle} •{' '}
+                <Text as='span' color='gray.300'>
+                  {job.jobType}
+                </Text>
               </Text>
-            )}
-          </Box>
-        )
-      })}
-    </Box>
-  </>
-)
+
+              <Text fontSize='1.4rem' lineHeight={lineHeight} color='gray.300'>
+                {startDate} &#8212; {endDate} • {duration}
+              </Text>
+
+              {job.detail && <Text lineHeight={lineHeight}>{job.detail}</Text>}
+              {job.stack && (
+                <Text
+                  fontSize='1.4rem'
+                  lineHeight={lineHeight}
+                  color='gray.300'
+                >
+                  {job.stack}
+                </Text>
+              )}
+            </Box>
+          )
+        })}
+      </Box>
+    </>
+  )
+}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,11 +5,13 @@ import { ThemeProvider } from 'styled-components'
 import GlobalStyle from '../components/GlobalStyle'
 import PrinterLayout from './PrinterLayout'
 import SiteLayout from './SiteLayout'
-import theme from '../theme'
+import theme, { printTheme } from '../theme'
 
 const Layout = ({ children, pageContext }) => {
+  const isPrinter = pageContext?.layout === 'printer'
+
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={isPrinter ? printTheme : theme}>
       <Helmet>
         <link
           href='https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700|Arvo:400,700'
@@ -19,7 +21,7 @@ const Layout = ({ children, pageContext }) => {
 
       <GlobalStyle />
 
-      {pageContext?.layout === 'printer' ? (
+      {isPrinter ? (
         <PrinterLayout>{children}</PrinterLayout>
       ) : (
         <SiteLayout>{children}</SiteLayout>

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -40,9 +40,9 @@ const ResumePage = (props) => {
             Software Engineer
           </Text>
 
-          <AboutMe personal={false} />
+          <AboutMe personal={false} compact />
 
-          <Experience />
+          <Experience compact />
         </Container>
       </Section>
     </>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -44,6 +44,8 @@ const fontSizes = [0, 5, 7, 9, 12, 16, 21, 28, 37, 50, 67, 89].map(
 
 const fontWeights = [0, 400, 500, 600, 700]
 
+const baseFontSize = '62.5%' // 1rem = 10px of the default 16px browser font-size
+
 const theme = {
   colors,
   space,
@@ -51,6 +53,7 @@ const theme = {
   fonts,
   fontSizes,
   fontWeights,
+  baseFontSize,
 }
 
 const themes = {
@@ -67,5 +70,23 @@ const themes = {
 
 // const linearGradient = (color) =>
 //   `linear-gradient(90deg, ${rgba(color, 0)} 0%, ${rgba(color, 1)} 100%)`
+
+// The /resume PDF export (PrinterLayout) needs to fit on one physical page.
+// These two factors shrink every rem-based size (headings and body copy, via
+// baseFontSize) and every space-prop margin/padding (Section's py, heading
+// and job gaps, via the space scale) proportionally, so nothing needs
+// hand-tuning per element. Only the /resume route uses this theme — see
+// Layout.tsx, which selects it when `pageContext.layout === 'printer'`.
+const PRINT_FONT_SCALE = 0.72
+const PRINT_SPACE_SCALE = 0.125
+
+export const printTheme = {
+  ...themes.dark,
+  baseFontSize: `${parseFloat(baseFontSize) * PRINT_FONT_SCALE}%`,
+  space: {
+    ...spaceScale.map((n) => Math.round(n * PRINT_SPACE_SCALE)),
+    ...componentsScale,
+  },
+}
 
 export default themes.dark


### PR DESCRIPTION
## What
Fits the printable resume (/resume) onto a single page. The /about page is unchanged.

## How
- A print-only theme scoped to the printer layout that reduces the base font size and the section spacing scale.
- A compact mode on the shared About/Experience components (tighter line-height), used only by /resume.

## Heads up
Check /resume on the preview and export the PDF. The compaction may be a touch aggressive — if the text reads too small, it is a two-value tweak to soften.
