### PR TITLE
fix: update availability status and stale site metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: 'Iago Dahlem Lorensini',
     description:
-      "Hey there! I'm Iago. A software engineer working at Codeminer42",
+      "Hey there! I'm Iago — a software engineer from Florianópolis, Brazil. Most recently at Clerk, now open to new roles and consulting.",
     siteUrl: 'https://iagodahlem.com',
     author: {
       name: 'Iago Dahlem Lorensini',

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -41,12 +41,12 @@ const Seo: FC<Props> = ({
   )
 
   const seo = {
+    ...siteMetadata,
     title: title || siteMetadata.title,
-    description,
+    description: description || siteMetadata.description,
     canonicalUrl: pathname
       ? `${siteMetadata.siteUrl}${pathname.replace(/\/$/, '')}`
       : siteMetadata.siteUrl,
-    ...siteMetadata,
   }
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,14 +40,15 @@ const IndexPage = ({ data }) => {
             Hi! 👋 I'm Iago.
             <br />A software engineer from Brazil.
             <br />
-            I'm currently working at{' '}
+            Most recently at{' '}
             <Text
               as={motion.a}
               href='https://clerk.com'
               whileHover={{ opacity: 0.6 }}
             >
               Clerk.com
-            </Text>
+            </Text>{' '}
+            — now open to new roles and consulting.
           </Text>
 
           <Nav />


### PR DESCRIPTION
## What

- Homepage hero said "I'm currently working at Clerk.com" — now reads "Most recently at Clerk.com — now open to new roles and consulting."
- Site-wide meta description in `gatsby-config.js` still said "working at Codeminer42" — replaced with current copy matching the new hero.
- Fixed a precedence bug in `Seo.tsx`: `...siteMetadata` was spread last, so the stale site description (and site title) always overrode whatever each page passed in. It now spreads first, with the site description as fallback for pages that don't pass one. Verified in the built output: `/` renders the new site description, `/about` renders its own "About Me".

## Notes

- PR #248 (single-page resume) is untouched — no overlapping files, no conflicts.
- Not changed: the Clerk end date in `src/content/about.tsx` (July 09, 2026) stays as-is.